### PR TITLE
Fix/23 mypage update exception

### DIFF
--- a/src/main/java/com/sparta/newspeed/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/newspeed/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     FAIL(500, "실패했습니다."),
     USER_NOT_FOUND(400, "해당하는 유저를 찾을 수 없습니다."),
     USER_NOT_VALID(400, "이미 탈퇴 처리된 유저입니다."),
+    DUPLICATE_PASSWORD(400, "기존 비밀번호와 동일한 비밀번호입니다."),
     USER_NOT_UNIQUE(400,"중복된 사용자가 존재합니다."),
     INCORRECT_PASSWORD(400, "입력하신 비밀번호가 일치하지 않습니다."),
     NEWSFEED_NOT_FOUND(404,"뉴스피드를 찾을 수 없습니다."),

--- a/src/main/java/com/sparta/newspeed/user/dto/UserInfoUpdateDto.java
+++ b/src/main/java/com/sparta/newspeed/user/dto/UserInfoUpdateDto.java
@@ -17,6 +17,6 @@ public class UserInfoUpdateDto {
 
     public UserInfoUpdateDto(User user) {
         this.name = user.getUserName();
-        this.intro = user.getUserEmail();
+        this.intro = user.getUserIntro();
     }
 }

--- a/src/main/java/com/sparta/newspeed/user/entity/User.java
+++ b/src/main/java/com/sparta/newspeed/user/entity/User.java
@@ -5,7 +5,6 @@ import com.sparta.newspeed.user.dto.UserInfoUpdateDto;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -65,7 +64,7 @@ public class User extends Timestamped {
         this.userIntro = requestDto.getIntro();
     }
 
-    public void setUserPassword(String encNewPassword) {
+    public void updatePassword(String encNewPassword) {
         this.userPassword = encNewPassword;
     }
 

--- a/src/main/java/com/sparta/newspeed/user/service/UserService.java
+++ b/src/main/java/com/sparta/newspeed/user/service/UserService.java
@@ -1,9 +1,7 @@
 package com.sparta.newspeed.user.service;
 
-import com.sparta.newspeed.auth.dto.SignUpRequestDto;
 import com.sparta.newspeed.common.exception.CustomException;
 import com.sparta.newspeed.common.exception.ErrorCode;
-import com.sparta.newspeed.security.service.UserDetailsImpl;
 import com.sparta.newspeed.user.dto.UserInfoUpdateDto;
 import com.sparta.newspeed.user.dto.UserPwRequestDto;
 import com.sparta.newspeed.user.dto.UserResponseDto;
@@ -50,7 +48,11 @@ public class UserService {
             throw new CustomException(ErrorCode.INCORRECT_PASSWORD);
         }
 
-        user.setUserPassword(passwordEncoder.encode(requestDto.getNewPassword()));
+        if (passwordEncoder.matches(requestDto.getNewPassword(), user.getUserPassword())) {
+            throw new CustomException(ErrorCode.DUPLICATE_PASSWORD);
+        }
+
+        user.updatePassword(passwordEncoder.encode(requestDto.getNewPassword()));
     }
 
     @Transactional
@@ -73,5 +75,4 @@ public class UserService {
         // 회원 상태를 탈퇴로 변경
         user.UpdateRole(UserRoleEnum.WITHDRAW);
     }
-
 }

--- a/src/test/java/com/sparta/newspeed/user/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/newspeed/user/service/UserServiceTest.java
@@ -67,7 +67,7 @@ class UserServiceTest {
     void updateUser() {
         UserInfoUpdateDto updateUser = new UserInfoUpdateDto(
                 "updateName",
-                "test1@test1.com",
+//                "test1@test1.com",
                 "update_intro"
         );
         userService.updateUser(1L, updateUser);


### PR DESCRIPTION
#23 
프로필 수정 로직 수정
- 한 줄소개 값에 email이 리턴되던 이슈 수정
- 현재 비밀번호와 동일한 비밀번호로 수정하는 경우 예외처리